### PR TITLE
Revert pull request #28 and fix minor bugs in psi_common_math_pkg.from_str()

### DIFF
--- a/hdl/psi_common_math_pkg.vhd
+++ b/hdl/psi_common_math_pkg.vhd
@@ -397,6 +397,7 @@ package body psi_common_math_pkg is
   
   -- convert string to real
   function from_str(input : string) return real is
+    constant Nbsp_c : character := character'val(160);
     variable Idx_v : integer := input'low;
     variable IsNeg_v : boolean := false;
     variable ValInt_v : integer := 0;
@@ -406,14 +407,14 @@ package body psi_common_math_pkg is
     variable ExpNeg_v : boolean := false;
     variable ValAbs_v : real := 0.0;
   begin
-    -- skip leading white-spaces
-    while (Idx_v <= input'high) and input(Idx_v) = ' ' loop
+    -- skip leading white-spaces (space, non-breaking space or horizontal tab)
+    while (Idx_v <= input'high) and (input(Idx_v) = ' ' or input(Idx_v) = Nbsp_c or input(Idx_v) = HT) loop
       Idx_v := Idx_v + 1;
     end loop;
     
     -- Check sign
-    if (Idx_v <= input'high) and (input(Idx_v) = '-') then
-      IsNeg_v := true;
+    if (Idx_v <= input'high) and ((input(Idx_v) = '-') or (input(Idx_v) = '+')) then
+      IsNeg_v := (input(Idx_v) = '-');
       Idx_v := Idx_v + 1;
     end if;
     
@@ -442,8 +443,8 @@ package body psi_common_math_pkg is
       if (input(Idx_v) = 'E') or (input(Idx_v) = 'e') then
         Idx_v := Idx_v + 1;
         -- Check sign
-        if (Idx_v <= input'high) and (input(Idx_v) = '-') then
-          ExpNeg_v := true;
+        if (Idx_v <= input'high) and ((input(Idx_v) = '-') or (input(Idx_v) = '+')) then
+          ExpNeg_v := (input(Idx_v) = '-');
           Idx_v := Idx_v + 1;
         end if;
         

--- a/hdl/psi_common_math_pkg.vhd
+++ b/hdl/psi_common_math_pkg.vhd
@@ -12,9 +12,6 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 use ieee.math_real.all;
 
-library std;
-use std.textio.all;
-
 library work;
 use work.psi_common_array_pkg.all;
 
@@ -400,12 +397,74 @@ package body psi_common_math_pkg is
   
   -- convert string to real
   function from_str(input : string) return real is
-    variable line_v : line := new string'(input);
-    variable v      : real;
+    variable Idx_v : integer := input'low;
+    variable IsNeg_v : boolean := false;
+    variable ValInt_v : integer := 0;
+    variable ValFrac_v : real := 0.0;
+    variable FracDigits_v : integer := 0;
+    variable Exp_v : integer := 0;
+    variable ExpNeg_v : boolean := false;
+    variable ValAbs_v : real := 0.0;
   begin
-    read(line_v, v);
-    deallocate(line_v);
-    return v;
+    -- skip leading white-spaces
+    while (Idx_v <= input'high) and input(Idx_v) = ' ' loop
+      Idx_v := Idx_v + 1;
+    end loop;
+    
+    -- Check sign
+    if (Idx_v <= input'high) and (input(Idx_v) = '-') then
+      IsNeg_v := true;
+      Idx_v := Idx_v + 1;
+    end if;
+    
+    -- Parse Integer
+    while (Idx_v <= input'high) and (input(Idx_v) <= '9') and (input(Idx_v) >= '0') loop
+      ValInt_v := ValInt_v*10 + (character'pos(input(Idx_v))-character'pos('0'));
+      Idx_v := Idx_v + 1;
+    end loop;
+    
+    -- Check decimal point
+    if (Idx_v <= input'high) then
+      if input(Idx_v) = '.' then
+        Idx_v := Idx_v + 1;
+    
+        -- Parse Fractional
+        while (Idx_v <= input'high) and (input(Idx_v) <= '9') and (input(Idx_v) >= '0') loop
+          ValFrac_v := ValFrac_v*10.0 + real((character'pos(input(Idx_v))-character'pos('0')));
+          FracDigits_v := FracDigits_v + 1;
+          Idx_v := Idx_v + 1;
+        end loop;
+      end if;
+    end if;
+    
+    -- Check exponent
+    if (Idx_v <= input'high) then
+      if (input(Idx_v) = 'E') or (input(Idx_v) = 'e') then
+        Idx_v := Idx_v + 1;
+        -- Check sign
+        if (Idx_v <= input'high) and (input(Idx_v) = '-') then
+          ExpNeg_v := true;
+          Idx_v := Idx_v + 1;
+        end if;
+        
+        -- Parse Integer
+        while (Idx_v <= input'high) and (input(Idx_v) <= '9') and (input(Idx_v) >= '0') loop
+          Exp_v := Exp_v*10 + (character'pos(input(Idx_v))-character'pos('0'));
+          Idx_v := Idx_v + 1;
+        end loop;
+        if ExpNeg_v then
+          Exp_v := -Exp_v;
+        end if;
+      end if;
+    end if;
+    
+    -- Return
+    ValAbs_v := (real(ValInt_v)+ValFrac_v/10.0**real(FracDigits_v))*10.0**real(Exp_v);
+    if IsNeg_v then
+      return -ValAbs_v;
+    else
+      return ValAbs_v;
+    end if; 
   end function;
   
   -- convert string to real array


### PR DESCRIPTION
Pull request #28 broke synthesis in Xilinx Vivado 2020.1 because Vivado doesn't fully support VHDL-93 yet. (Specifically, `std.textio.line` is an `access` type, which is not supported by Vivado).

Therefore, I reverted that change (a2c6456), then implemented minor bug fixes for handling explicit "+" signs in `from_str()` (be3e56d).

I used the GHDL implementation of `std.textio.read()` as a reference and tried to get behavior as close as possible to that (but still without any error checking):
https://github.com/ghdl/ghdl/blob/master/libraries/std/textio-body.vhdl

This fixes the issues in my use cases. And when I run this very simple testbench in Modelsim (2020.1 AE) ...

```vhdl
use work.psi_common_math_pkg.all;

entity tb1 is
end;

architecture sim of tb1 is
    
begin
    
    process
    begin
        report real'image(from_str("1.23")) severity Note;
        report real'image(from_str("+4.56")) severity Note;
        report real'image(from_str("+7.89e+03")) severity Note;
        report real'image(from_str("+8.76e+03")) severity Note;
        report real'image(from_str("-8.76e-03")) severity Note;
        wait;
    end process;
    
end;
```

... this produces the expected output:

```
# ** Note: 1.230000e+00
#    Time: 0 ps  Iteration: 0  Instance: /tb1
# ** Note: 4.560000e+00
#    Time: 0 ps  Iteration: 0  Instance: /tb1
# ** Note: 7.890000e+03
#    Time: 0 ps  Iteration: 0  Instance: /tb1
# ** Note: 8.760000e+03
#    Time: 0 ps  Iteration: 0  Instance: /tb1
# ** Note: -8.760000e-03
#    Time: 0 ps  Iteration: 0  Instance: /tb1
```