### PR TITLE
Fix issues with undefined signals before reset in psi_common_pl_stage…

### DIFF
--- a/hdl/psi_common_pl_stage.vhd
+++ b/hdl/psi_common_pl_stage.vhd
@@ -122,7 +122,9 @@ begin
       if rising_edge(Clk) then
         r <= r_next;
         if Rst = '1' then
+          r.DataMain <= (others => '0');
           r.DataMainVld <= '0';
+          r.DataShad <= (others => '0');
           r.DataShadVld <= '0';
           r.InRdy       <= '1';
         end if;

--- a/hdl/psi_common_pl_stage.vhd
+++ b/hdl/psi_common_pl_stage.vhd
@@ -122,9 +122,7 @@ begin
       if rising_edge(Clk) then
         r <= r_next;
         if Rst = '1' then
-          r.DataMain <= (others => '0');
           r.DataMainVld <= '0';
-          r.DataShad <= (others => '0');
           r.DataShadVld <= '0';
           r.InRdy       <= '1';
         end if;

--- a/hdl/psi_common_sync_fifo.vhd
+++ b/hdl/psi_common_sync_fifo.vhd
@@ -144,12 +144,12 @@ begin
     RamRdAddr <= v.RdAddr;
 
     -- Read side status
-    if unsigned(r.RdLevel) = 0 then
-      OutVld <= '0';
-      Empty  <= '1';
-    else
+    if unsigned(r.RdLevel) > 0 then
       OutVld <= '1';
       Empty  <= '0';
+    else
+      OutVld <= '0';
+      Empty  <= '1';
     end if;
 
     if AlmEmptyOn_g and unsigned(r.RdLevel) <= AlmEmptyLevel_g then

--- a/hdl/psi_common_sync_fifo.vhd
+++ b/hdl/psi_common_sync_fifo.vhd
@@ -144,12 +144,12 @@ begin
     RamRdAddr <= v.RdAddr;
 
     -- Read side status
-    if unsigned(r.RdLevel) > 0 then
-      OutVld <= '1';
-      Empty  <= '0';
-    else
+    if unsigned(r.RdLevel) = 0 then
       OutVld <= '0';
       Empty  <= '1';
+    else
+      OutVld <= '1';
+      Empty  <= '0';
     end if;
 
     if AlmEmptyOn_g and unsigned(r.RdLevel) <= AlmEmptyLevel_g then


### PR DESCRIPTION
Hi

I fixed two issues with undefined signals which caused issues with the axi stream protocol checker in vunit:

- in psi_common_pl_stage.vhd the two registers DataMain and DataShad were not initialized or set during reset which result that the output is undefined until the first clock cycle
- in psi_common_sync_fifo.vhd the OutVld signal is active before reset because r.RdLevel is undefined