### PR TITLE
Fix FIFOs level ports width

### DIFF
--- a/hdl/psi_common_async_fifo.vhd
+++ b/hdl/psi_common_async_fifo.vhd
@@ -56,13 +56,13 @@ entity psi_common_async_fifo is
     InEmpty     : out std_logic;
     InAlmFull   : out std_logic;
     InAlmEmpty  : out std_logic;
-    InLevel     : out std_logic_vector(log2ceil(Depth_g) downto 0);
+    InLevel     : out std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0);
     -- Output Status
     OutFull     : out std_logic;
     OutEmpty    : out std_logic;
     OutAlmFull  : out std_logic;
     OutAlmEmpty : out std_logic;
-    OutLevel    : out std_logic_vector(log2ceil(Depth_g) downto 0)
+    OutLevel    : out std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0)
   );
 end entity;
 
@@ -160,7 +160,7 @@ begin
         RamWr     <= '1';
       end if;
     end if;
-    -- Artificially keep InRdy low during reset if required 
+    -- Artificially keep InRdy low during reset if required
     if (RdyRstState_g = '0') and (RstInInt = '1') then
       InRdy <= '0';
     end if;

--- a/hdl/psi_common_sync_fifo.vhd
+++ b/hdl/psi_common_sync_fifo.vhd
@@ -7,7 +7,7 @@
 ------------------------------------------------------------------------------
 -- Description
 ------------------------------------------------------------------------------
--- This is a very basic synchronous FIFO. It  has optional level- and 
+-- This is a very basic synchronous FIFO. It  has optional level- and
 -- almost-full/empty ports.
 
 ------------------------------------------------------------------------------
@@ -51,11 +51,11 @@ entity psi_common_sync_fifo is
     -- Input Status
     Full     : out std_logic;
     AlmFull  : out std_logic;
-    InLevel  : out std_logic_vector(log2ceil(Depth_g) downto 0);
+    InLevel  : out std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0);
     -- Output Status
     Empty    : out std_logic;
     AlmEmpty : out std_logic;
-    OutLevel : out std_logic_vector(log2ceil(Depth_g) downto 0)
+    OutLevel : out std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0);
   );
 end entity;
 
@@ -115,7 +115,7 @@ begin
       InRdy <= '1';
       Full  <= '0';
     end if;
-    -- Artificially keep InRdy low during reset if required 
+    -- Artificially keep InRdy low during reset if required
     if (RdyRstState_g = '0') and (Rst = '1') then
       InRdy <= '0';
     end if;
@@ -187,7 +187,7 @@ begin
 
   --------------------------------------------------------------------------
   -- Component Instantiations
-  --------------------------------------------------------------------------	
+  --------------------------------------------------------------------------
   i_ram : entity work.psi_common_sdp_ram
     generic map(
       Depth_g    => Depth_g,

--- a/testbench/psi_common_async_fifo_tb/psi_common_async_fifo_tb.vhd
+++ b/testbench/psi_common_async_fifo_tb/psi_common_async_fifo_tb.vhd
@@ -30,7 +30,7 @@ architecture sim of psi_common_async_fifo_tb is
 
   -------------------------------------------------------------------------
   -- Constants
-  -------------------------------------------------------------------------	
+  -------------------------------------------------------------------------
   constant DataWidth_c     : integer := 16;
   constant AlmFullLevel_c  : natural := Depth_g - 3;
   constant AlmEmptyLevel_c : natural := 5;
@@ -49,26 +49,26 @@ architecture sim of psi_common_async_fifo_tb is
   -------------------------------------------------------------------------
   -- Interface Signals
   -------------------------------------------------------------------------
-  signal InClk       : std_logic                                    := '0';
-  signal InRst       : std_logic                                    := '1';
-  signal OutClk      : std_logic                                    := '0';
-  signal OutRst      : std_logic                                    := '1';
-  signal InData      : std_logic_vector(DataWidth_c - 1 downto 0)   := (others => '0');
-  signal InVld       : std_logic                                    := '0';
-  signal InRdy       : std_logic                                    := '0';
-  signal OutData     : std_logic_vector(DataWidth_c - 1 downto 0)   := (others => '0');
-  signal OutVld      : std_logic                                    := '0';
-  signal OutRdy      : std_logic                                    := '0';
-  signal InFull      : std_logic                                    := '0';
-  signal OutFull     : std_logic                                    := '0';
-  signal InEmpty     : std_logic                                    := '0';
-  signal OutEmpty    : std_logic                                    := '0';
-  signal InAlmFull   : std_logic                                    := '0';
-  signal OutAlmFull  : std_logic                                    := '0';
-  signal InAlmEmpty  : std_logic                                    := '0';
-  signal OutAlmEmpty : std_logic                                    := '0';
-  signal InLevel     : std_logic_vector(log2ceil(Depth_g) downto 0) := (others => '0');
-  signal OutLevel    : std_logic_vector(log2ceil(Depth_g) downto 0) := (others => '0');
+  signal InClk       : std_logic                                            := '0';
+  signal InRst       : std_logic                                            := '1';
+  signal OutClk      : std_logic                                            := '0';
+  signal OutRst      : std_logic                                            := '1';
+  signal InData      : std_logic_vector(DataWidth_c - 1 downto 0)           := (others => '0');
+  signal InVld       : std_logic                                            := '0';
+  signal InRdy       : std_logic                                            := '0';
+  signal OutData     : std_logic_vector(DataWidth_c - 1 downto 0)           := (others => '0');
+  signal OutVld      : std_logic                                            := '0';
+  signal OutRdy      : std_logic                                            := '0';
+  signal InFull      : std_logic                                            := '0';
+  signal OutFull     : std_logic                                            := '0';
+  signal InEmpty     : std_logic                                            := '0';
+  signal OutEmpty    : std_logic                                            := '0';
+  signal InAlmFull   : std_logic                                            := '0';
+  signal OutAlmFull  : std_logic                                            := '0';
+  signal InAlmEmpty  : std_logic                                            := '0';
+  signal OutAlmEmpty : std_logic                                            := '0';
+  signal InLevel     : std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0) := (others => '0');
+  signal OutLevel    : std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0) := (others => '0');
 
 begin
 

--- a/testbench/psi_common_sync_fifo_tb/psi_common_sync_fifo_tb.vhd
+++ b/testbench/psi_common_sync_fifo_tb/psi_common_sync_fifo_tb.vhd
@@ -30,7 +30,7 @@ architecture sim of psi_common_sync_fifo_tb is
 
   -------------------------------------------------------------------------
   -- Constants
-  -------------------------------------------------------------------------	
+  -------------------------------------------------------------------------
   constant DataWidth_c     : integer := 16;
   constant AlmFullLevel_c  : natural := Depth_g - 3;
   constant AlmEmptyLevel_c : natural := 5;
@@ -45,20 +45,20 @@ architecture sim of psi_common_sync_fifo_tb is
   -------------------------------------------------------------------------
   -- Interface Signals
   -------------------------------------------------------------------------
-  signal Clk      : std_logic                                    := '0';
-  signal Rst      : std_logic                                    := '1';
-  signal InData   : std_logic_vector(DataWidth_c - 1 downto 0)   := (others => '0');
-  signal InVld    : std_logic                                    := '0';
-  signal InRdy    : std_logic                                    := '0';
-  signal OutData  : std_logic_vector(DataWidth_c - 1 downto 0)   := (others => '0');
-  signal OutVld   : std_logic                                    := '0';
-  signal OutRdy   : std_logic                                    := '0';
-  signal Full     : std_logic                                    := '0';
-  signal Empty    : std_logic                                    := '0';
-  signal AlmFull  : std_logic                                    := '0';
-  signal AlmEmpty : std_logic                                    := '0';
-  signal InLevel  : std_logic_vector(log2ceil(Depth_g) downto 0) := (others => '0');
-  signal OutLevel : std_logic_vector(log2ceil(Depth_g) downto 0) := (others => '0');
+  signal Clk      : std_logic                                               := '0';
+  signal Rst      : std_logic                                               := '1';
+  signal InData   : std_logic_vector(DataWidth_c - 1 downto 0)              := (others => '0');
+  signal InVld    : std_logic                                               := '0';
+  signal InRdy    : std_logic                                               := '0';
+  signal OutData  : std_logic_vector(DataWidth_c - 1 downto 0)              := (others => '0');
+  signal OutVld   : std_logic                                               := '0';
+  signal OutRdy   : std_logic                                               := '0';
+  signal Full     : std_logic                                               := '0';
+  signal Empty    : std_logic                                               := '0';
+  signal AlmFull  : std_logic                                               := '0';
+  signal AlmEmpty : std_logic                                               := '0';
+  signal InLevel  : std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0)    := (others => '0');
+  signal OutLevel : std_logic_vector(log2ceil(Depth_g + 1) - 1 downto 0)    := (others => '0');
 
 begin
 


### PR DESCRIPTION
- Fix InLevel and OutLevel width definition to the exact number of bits required for the configured depth.
- Previous implementation resulted in 1 extra bit for every depth except powers of 2

- This fix will have impact on projects using the psi_common_sync_fifo and psi_common_async_fifo